### PR TITLE
fix: unblock latest-version resolution (deprecate archived pkgs, fix false CI failure)

### DIFF
--- a/.github/workflows/alpha_constraints.yml
+++ b/.github/workflows/alpha_constraints.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Commit generated constraints files
         run: |
           git add constraints-alpha.txt
-          git commit -m "Update constraints files"
+          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gen_constraints.yml
+++ b/.github/workflows/gen_constraints.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Commit generated constraints files
         run: |
           git add constraints-stable.txt
-          git commit -m "Update constraints files"
+          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing_constraints.yml
+++ b/.github/workflows/testing_constraints.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Commit generated constraints files
         run: |
           git add constraints-testing.txt
-          git commit -m "Update constraints files"
+          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lists/deprecated.list
+++ b/lists/deprecated.list
@@ -2,3 +2,5 @@ ovos-phal-plugin-balena-wifi
 ovos-classifiers
 ovos-ww-plugin-precise-lite
 ovos-solver-yes-no-plugin
+ovos-PHAL-plugin-wifi-setup
+ovos-gui-plugin-shell-companion

--- a/lists/gui.list
+++ b/lists/gui.list
@@ -1,1 +1,1 @@
-ovos-gui-plugin-shell-companion
+

--- a/lists/phal.list
+++ b/lists/phal.list
@@ -6,7 +6,6 @@ ovos-phal-plugin-system
 ovos-PHAL-plugin-network-manager
 ovos-PHAL-plugin-wallpaper-manager
 ovos-PHAL-plugin-mk1
-ovos-PHAL-plugin-wifi-setup
 ovos-PHAL-plugin-hotkeys
 ovos-PHAL-plugin-mk2-fan-control
 #ovos-PHAL-plugin-termux


### PR DESCRIPTION
Diagnosed why `Generate Alpha Constraints` won't resolve the latest versions together.

## 1. Archived packages pin old caps forever
Two **archived** packages were still in the active resolution lists:
- `ovos-PHAL-plugin-wifi-setup` → `ovos-workshop<8.1.0`, `ovos-bus-client<2.0.0`
- `ovos-gui-plugin-shell-companion` → `ovos-bus-client<2.0.0`

Moved both to `deprecated.list` (not included by `gather_packages.sh`), matching the existing convention.

## 2. False CI failure on unchanged output
`alpha_constraints.yml`, `gen_constraints.yml`, `testing_constraints.yml` run a bare `git commit` that exits 1 ("nothing to commit") when the regenerated constraints are unchanged — failing a successful run. Guarded with `git diff --staged --quiet ||` (same pattern as `make_alpha_testing.yml`/`conflict_report.yml`).

> Does not alone make workshop 8.x / bus-client 2.x resolve — those are blocked by upstream repos whose merged fixes haven't published (broken release pipelines) and by `hivemind-core` requiring `bus-client<2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows to prevent unnecessary constraint generation commits by adding skip CI markers when no changes are staged
  * Added three components to the deprecated list, moving them from active distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->