### PR TITLE
Tell the container image repositories when the pins move

### DIFF
--- a/.github/workflows/alpha_constraints.yml
+++ b/.github/workflows/alpha_constraints.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # the generated constraints are committed back to the branch
     env:
-      # Token with contents:write on the container image repositories, used only to tell
-      # them that the pins moved. Optional: without it the dispatch step is skipped and
-      # the images fall back to their own hourly poll.
-      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
+      # Whether the notification below can run. Only the answer lives at job scope: a
+      # secret cannot be read from an `if:` condition, and the token itself must not be
+      # exposed to the dependency installs and release scripts that run in this job.
+      HAS_DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -61,9 +63,9 @@ jobs:
         # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
         # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
         # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
-        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        if: steps.commit.outputs.changed == 'true' && env.HAS_DISPATCH_TOKEN == 'true'
         env:
-          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
         run: |
           for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
             if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"alpha"}}' \

--- a/.github/workflows/alpha_constraints.yml
+++ b/.github/workflows/alpha_constraints.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    env:
+      # Token with contents:write on the container image repositories, used only to tell
+      # them that the pins moved. Optional: without it the dispatch step is skipped and
+      # the images fall back to their own hourly poll.
+      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -38,9 +43,33 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit generated constraints files
+        id: commit
         run: |
           git add constraints-alpha.txt
-          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
-          git push
+          if git diff --staged --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "Update constraints files [skip ci]"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tell the container images that the alpha pins moved
+        # ovos-docker and hivemind-docker install every package against
+        # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
+        # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
+        # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
+        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+        run: |
+          for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
+            if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"alpha"}}' \
+              | gh api --method POST "repos/${repo}/dispatches" --input -; then
+              echo "asked ${repo} to rebuild what alpha changed"
+            else
+              echo "::warning::could not notify ${repo}; its hourly poll will pick this up"
+            fi
+          done

--- a/.github/workflows/gen_constraints.yml
+++ b/.github/workflows/gen_constraints.yml
@@ -6,11 +6,13 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # the generated constraints are committed back to the branch
     env:
-      # Token with contents:write on the container image repositories, used only to tell
-      # them that the pins moved. Optional: without it the dispatch step is skipped and
-      # the images fall back to their own hourly poll.
-      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
+      # Whether the notification below can run. Only the answer lives at job scope: a
+      # secret cannot be read from an `if:` condition, and the token itself must not be
+      # exposed to the dependency installs and release scripts that run in this job.
+      HAS_DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -59,9 +61,9 @@ jobs:
         # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
         # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
         # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
-        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        if: steps.commit.outputs.changed == 'true' && env.HAS_DISPATCH_TOKEN == 'true'
         env:
-          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
         run: |
           for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
             if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"stable"}}' \

--- a/.github/workflows/gen_constraints.yml
+++ b/.github/workflows/gen_constraints.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    env:
+      # Token with contents:write on the container image repositories, used only to tell
+      # them that the pins moved. Optional: without it the dispatch step is skipped and
+      # the images fall back to their own hourly poll.
+      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -36,9 +41,33 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit generated constraints files
+        id: commit
         run: |
           git add constraints-stable.txt
-          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
-          git push
+          if git diff --staged --quiet -- constraints-stable.txt; then
+            constraints_changed=false
+          else
+            constraints_changed=true
+          fi
+          git diff --staged --quiet || { git commit -m "Update constraints files [skip ci]"; git push; }
+          echo "changed=${constraints_changed}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tell the container images that the stable pins moved
+        # ovos-docker and hivemind-docker install every package against
+        # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
+        # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
+        # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
+        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+        run: |
+          for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
+            if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"stable"}}' \
+              | gh api --method POST "repos/${repo}/dispatches" --input -; then
+              echo "asked ${repo} to rebuild what stable changed"
+            else
+              echo "::warning::could not notify ${repo}; its hourly poll will pick this up"
+            fi
+          done

--- a/.github/workflows/make_alpha_testing.yml
+++ b/.github/workflows/make_alpha_testing.yml
@@ -6,11 +6,13 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # the generated constraints are committed back to the branch
     env:
-      # Token with contents:write on the container image repositories, used only to tell
-      # them that the pins moved. Optional: without it the dispatch step is skipped and
-      # the images fall back to their own hourly poll.
-      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
+      # Whether the notification below can run. Only the answer lives at job scope: a
+      # secret cannot be read from an `if:` condition, and the token itself must not be
+      # exposed to the dependency installs and release scripts that run in this job.
+      HAS_DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -61,9 +63,9 @@ jobs:
         # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
         # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
         # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
-        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        if: steps.commit.outputs.changed == 'true' && env.HAS_DISPATCH_TOKEN == 'true'
         env:
-          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
         run: |
           for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
             if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"testing"}}' \

--- a/.github/workflows/make_alpha_testing.yml
+++ b/.github/workflows/make_alpha_testing.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      # Token with contents:write on the container image repositories, used only to tell
+      # them that the pins moved. Optional: without it the dispatch step is skipped and
+      # the images fall back to their own hourly poll.
+      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -38,9 +43,33 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit results
+        id: commit
         run: |
           git add constraints-testing.txt lists/unstable.list lists/deprecated.list docs/conflicts.md
-          git diff --staged --quiet || git commit -m "Sync testing constraints from alpha [skip ci]"
-          git push
+          if git diff --staged --quiet -- constraints-testing.txt; then
+            constraints_changed=false
+          else
+            constraints_changed=true
+          fi
+          git diff --staged --quiet || { git commit -m "Sync testing constraints from alpha [skip ci]"; git push; }
+          echo "changed=${constraints_changed}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tell the container images that the testing pins moved
+        # ovos-docker and hivemind-docker install every package against
+        # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
+        # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
+        # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
+        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+        run: |
+          for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
+            if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"testing"}}' \
+              | gh api --method POST "repos/${repo}/dispatches" --input -; then
+              echo "asked ${repo} to rebuild what testing changed"
+            else
+              echo "::warning::could not notify ${repo}; its hourly poll will pick this up"
+            fi
+          done

--- a/.github/workflows/testing_constraints.yml
+++ b/.github/workflows/testing_constraints.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    env:
+      # Token with contents:write on the container image repositories, used only to tell
+      # them that the pins moved. Optional: without it the dispatch step is skipped and
+      # the images fall back to their own hourly poll.
+      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -36,9 +41,33 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit generated constraints files
+        id: commit
         run: |
           git add constraints-testing.txt
-          git diff --staged --quiet || git commit -m "Update constraints files [skip ci]"
-          git push
+          if git diff --staged --quiet -- constraints-testing.txt; then
+            constraints_changed=false
+          else
+            constraints_changed=true
+          fi
+          git diff --staged --quiet || { git commit -m "Update constraints files [skip ci]"; git push; }
+          echo "changed=${constraints_changed}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tell the container images that the testing pins moved
+        # ovos-docker and hivemind-docker install every package against
+        # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
+        # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
+        # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
+        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+        run: |
+          for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
+            if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"testing"}}' \
+              | gh api --method POST "repos/${repo}/dispatches" --input -; then
+              echo "asked ${repo} to rebuild what testing changed"
+            else
+              echo "::warning::could not notify ${repo}; its hourly poll will pick this up"
+            fi
+          done

--- a/.github/workflows/testing_constraints.yml
+++ b/.github/workflows/testing_constraints.yml
@@ -6,11 +6,13 @@ on:
 jobs:
   generate-constraints:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # the generated constraints are committed back to the branch
     env:
-      # Token with contents:write on the container image repositories, used only to tell
-      # them that the pins moved. Optional: without it the dispatch step is skipped and
-      # the images fall back to their own hourly poll.
-      DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
+      # Whether the notification below can run. Only the answer lives at job scope: a
+      # secret cannot be read from an `if:` condition, and the token itself must not be
+      # exposed to the dependency installs and release scripts that run in this job.
+      HAS_DISPATCH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -59,9 +61,9 @@ jobs:
         # constraints-<channel>.txt, so a pin change here is what makes them rebuild.
         # They also poll hourly, but GitHub delays scheduled runs (in practice by hours),
         # so this dispatch is what makes the rebuild prompt; the poll stays as a fallback.
-        if: steps.commit.outputs.changed == 'true' && env.DISPATCH_TOKEN != ''
+        if: steps.commit.outputs.changed == 'true' && env.HAS_DISPATCH_TOKEN == 'true'
         env:
-          GH_TOKEN: ${{ env.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.IMAGE_DISPATCH_TOKEN }}
         run: |
           for repo in OpenVoiceOS/ovos-docker JarbasHiveMind/hivemind-docker; do
             if printf '%s' '{"event_type":"constraints-updated","client_payload":{"channel":"testing"}}' \


### PR DESCRIPTION
## Why

[ovos-docker](https://github.com/OpenVoiceOS/ovos-docker) and [hivemind-docker](https://github.com/JarbasHiveMind/hivemind-docker) install **every** package against `constraints-<channel>.txt` from this repository, so a pin change here is precisely what should trigger an image rebuild.

Both already listen for a `constraints-updated` `repository_dispatch` — but nothing has ever sent one, so their hourly poll is the only trigger. GitHub treats `schedule` as best-effort: the recent poll runs landed at 07:12, 01:24 and 22:49 UTC (gaps of 2–6 hours, not one), so a new alpha pin can sit unbuilt for most of a day.

## What

Each generator dispatches to both image repositories right after it commits, and **only when the constraints file it owns actually changed** — so a regeneration with no diff (the common case for the 6-hourly alpha run) notifies nobody:

| Workflow | Channel dispatched |
| --- | --- |
| `alpha_constraints.yml` | `alpha` |
| `testing_constraints.yml` | `testing` |
| `make_alpha_testing.yml` | `testing` (only when `constraints-testing.txt` changed, not the lists/docs it also commits) |
| `gen_constraints.yml` | `stable` |

The receiving side rebuilds only the images that contain a package whose pin moved, so a dispatch is cheap even when little changed.

## Setup needed for it to take effect

Add a repository secret **`IMAGE_DISPATCH_TOKEN`**: a fine-grained PAT with **contents: write** on `OpenVoiceOS/ovos-docker` and `JarbasHiveMind/hivemind-docker` (the permission `repository_dispatch` requires; `GITHUB_TOKEN` cannot reach another repository).

Until that secret exists every dispatch step is skipped by its `if`, so **merging this changes nothing** — the images keep relying on their poll. A failed dispatch logs a warning and never fails the run.

## Verification

Sent a real `constraints-updated` dispatch to ovos-docker: it triggered its `Publish on constraints change` workflow immediately ([run 33394510441](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33394510441)), confirming both the payload shape and the receiving end. All four workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Automation**
  - Constraint updates are now committed and pushed only when changes are detected.
  - Downstream container images can receive immediate update notifications for alpha, testing, and stable channels.
  - If notifications are unavailable or fail, hourly polling remains as a fallback.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->